### PR TITLE
Feat/input page

### DIFF
--- a/src/components/edit-reps-modal/edit-reps-modal.css
+++ b/src/components/edit-reps-modal/edit-reps-modal.css
@@ -1,0 +1,74 @@
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(95, 179, 163, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  backdrop-filter: blur(4px);
+}
+
+.modal-content {
+  background: white;
+  border-radius: 16px;
+  padding: 0;
+  width: 90%;
+  max-width: 400px;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.1);
+  animation: modalSlideIn 0.3s ease-out;
+}
+
+@keyframes modalSlideIn {
+  from {
+    opacity: 0;
+    transform: scale(0.9) translateY(-20px);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 24px 24px 16px 24px;
+  border-bottom: none;
+}
+
+.modal-title {
+  font-size: 20px;
+  font-weight: 600;
+  color: #333;
+  margin: 0;
+}
+
+.modal-close {
+  background: none;
+  border: none;
+  font-size: 24px;
+  color: #666;
+  cursor: pointer;
+  padding: 4px;
+  line-height: 1;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  transition: background-color 0.2s;
+}
+
+.modal-close:hover {
+  background: #f5f5f5;
+}
+
+.modal-body {
+  padding: 0 24px 24px 24px;
+}

--- a/src/components/edit-reps-modal/edit-reps-modal.tsx
+++ b/src/components/edit-reps-modal/edit-reps-modal.tsx
@@ -1,0 +1,37 @@
+import type { ReactNode, SyntheticEvent } from "react";
+import "./edit-reps-modal.css";
+
+type EditRepsModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  children?: ReactNode;
+};
+
+export function EditRepsModal({
+  isOpen,
+  onClose,
+  title,
+  children,
+}: EditRepsModalProps) {
+  if (!isOpen) return null;
+
+  const handleBackdropClick = (e: SyntheticEvent) => {
+    //when the modal overlay is clicked, but not the modal itself
+    if (e.target === e.currentTarget) onClose();
+  };
+
+  return (
+    <div className="modal-overlay" onClick={handleBackdropClick}>
+      <div className="modal-content">
+        <div className="modal-header">
+          <h2 className="modal-title">{title}</h2>
+          <button className="modal-close" onClick={onClose}>
+            ×
+          </button>
+        </div>
+        <div className="modal-body">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/screens/input/input.css
+++ b/src/screens/input/input.css
@@ -1,0 +1,102 @@
+.inputContainer {
+  min-height: 100vh;
+  background-color: #00c0a7;
+}
+
+.inputBody {
+  display: flex;
+  flex-direction: column;
+  padding-top: 4rem;
+  padding-bottom: 4rem;
+  align-items: center;
+  gap: 2rem;
+}
+
+h1 {
+  font-size: large;
+  color: white;
+}
+
+.gifContainer {
+  width: min(90vw, 90vh);
+  height: min(90vw, 90vh);
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  border-radius: 50%; /* Ensures it's always a circle */
+  background: radial-gradient(
+    circle at center,
+    #ffffff26 0%,
+    #ffffff26 40%,
+
+    #2ec8ad 40%,
+    #2ec8ad 60%,
+
+    #27c0a6 60%,
+    #27c0a6 80%,
+
+    #00c0a7 80%,
+    #00c0a7 100%
+  );
+}
+
+.gif {
+  max-width: 50%;
+  max-height: 50%;
+}
+
+.timer {
+  position: absolute;
+  font-size: 40px;
+  color: white;
+  text-align: center;
+  bottom: 1.25rem;
+  width: 100%;
+}
+
+.repsCounter {
+  border-top: 1px solid #ffffff7a;
+  border-bottom: 1px solid #ffffff7a;
+  padding: 1rem 0;
+  display: flex;
+  gap: 2rem;
+  flex-direction: row;
+  width: 100%;
+  align-items: center;
+}
+
+.repsText {
+  flex: 1 1 0%;
+}
+
+.footerContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 4rem;
+  width: 100%;
+  padding: 0 3rem;
+}
+
+.endTestBtn {
+  padding: 2rem;
+  border-radius: 1rem;
+  justify-items: center;
+  align-items: center;
+  background-color: white;
+  text-decoration: none;
+  color: #00c0a7;
+  cursor: pointer;
+}
+
+@media (min-width: 768px) {
+  .inputBody {
+    max-width: 50%;
+    margin: 0 auto;
+  }
+  .gifContainer {
+    width: min(50vw, 50vh);
+    height: min(50vw, 50vh);
+  }
+}

--- a/src/screens/input/input.css
+++ b/src/screens/input/input.css
@@ -88,6 +88,13 @@ h1 {
   text-decoration: none;
   color: #00c0a7;
   cursor: pointer;
+  border-style: none;
+}
+
+button {
+  background: transparent;
+  border-style: none;
+  cursor: pointer;
 }
 
 @media (min-width: 768px) {
@@ -99,4 +106,56 @@ h1 {
     width: min(50vw, 50vh);
     height: min(50vw, 50vh);
   }
+}
+
+.form-group {
+  margin-bottom: 24px;
+}
+
+.form-label {
+  display: block;
+  margin-bottom: 8px;
+  font-size: 16px;
+  color: #666;
+  font-weight: 500;
+}
+
+.form-input {
+  width: 100%;
+  padding: 16px;
+  border: 2px solid #e0e0e0;
+  border-radius: 12px;
+  font-size: 18px;
+  font-weight: 600;
+  color: #333;
+  background: #f8f8f8;
+  box-sizing: border-box;
+  transition: border-color 0.2s, background-color 0.2s;
+}
+
+.form-input:focus {
+  outline: none;
+  border-color: #5fb3a3;
+  background: white;
+}
+
+.update-btn {
+  width: 100%;
+  background: #00c0a7;
+  color: white;
+  border: none;
+  padding: 1.5rem;
+  border-radius: 12px;
+  font-size: large;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.update-btn:hover {
+  background: #4a9388;
+}
+
+.update-btn:active {
+  transform: translateY(1px);
 }

--- a/src/screens/input/input.tsx
+++ b/src/screens/input/input.tsx
@@ -1,10 +1,27 @@
 import "./input.css";
+import gif from "../../assets/sit_stand.gif";
+import { Pencil } from "lucide-react";
 
 export const Input = () => {
   return (
-    <div>
-      <h1>Input</h1>
-      <p>This is the input screen.</p>
+    <div className="inputContainer">
+      <div className="inputBody">
+        <h1>Sit & Stand Test</h1>
+        <div className="gifContainer">
+          <img src={gif} alt="Sit stand gif" className="gif" />
+          <h1 className="timer">00:00</h1>
+        </div>
+        <div className="footerContainer">
+          <div className="repsCounter">
+            <h1 className="repsText">Reps Counter</h1>
+            <h1>10</h1>
+            <Pencil color="white" />
+          </div>
+          <div className="endTestBtn">
+            <p>End Test</p>
+          </div>
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/screens/input/input.tsx
+++ b/src/screens/input/input.tsx
@@ -1,8 +1,21 @@
 import "./input.css";
 import gif from "../../assets/sit_stand.gif";
 import { Pencil } from "lucide-react";
+import { useState } from "react";
+import { EditRepsModal } from "../../components/edit-reps-modal/edit-reps-modal";
 
 export const Input = () => {
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(true);
+  const [count, setCount] = useState<number>(0);
+  //separated input val from count val so that the input field can be cleared completely
+  const [inputVal, setInputVal] = useState<string>("");
+
+  const handleUpdate = () => {
+    const numValue = inputVal === "" ? 0 : parseInt(inputVal) || 0;
+    setCount(numValue);
+    setIsModalOpen(false);
+  };
+
   return (
     <div className="inputContainer">
       <div className="inputBody">
@@ -14,14 +27,34 @@ export const Input = () => {
         <div className="footerContainer">
           <div className="repsCounter">
             <h1 className="repsText">Reps Counter</h1>
-            <h1>10</h1>
-            <Pencil color="white" />
+            <h1>{count}</h1>
+            <button onClick={() => setIsModalOpen(true)}>
+              <Pencil color="white" />
+            </button>
           </div>
-          <div className="endTestBtn">
+          <button className="endTestBtn">
             <p>End Test</p>
-          </div>
+          </button>
         </div>
       </div>
+      <EditRepsModal
+        onClose={() => setIsModalOpen(false)}
+        isOpen={isModalOpen}
+        title="Edit Reps"
+      >
+        <div className="form-group">
+          <label className="form-label">Count</label>
+          <input
+            type="number"
+            className="form-input"
+            value={inputVal}
+            onChange={(e) => setInputVal(e.target.value)}
+          />
+        </div>
+        <button className="update-btn" onClick={handleUpdate}>
+          Update
+        </button>
+      </EditRepsModal>
     </div>
   );
 };


### PR DESCRIPTION
Implement Input component / page

- layout
- styling
- sit stand gif
- concentric circles remain perfect circles across different viewport sizes
- end test button

Edit Reps Modal

- Reusable modal component with open and close animation & blurred background
- Accepts React Nodes as children for versitility
- Modal input state managed in the Input component